### PR TITLE
Fix when CI runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,15 +1,12 @@
 name: CI
 on:
   push:
-    branches:
-    - master
-    tags:
-    - 'v*'
+    branches: [master]
+    tags: '*'
   pull_request:
-    branches:
-    - master
+    types: [opened, synchronize, reopened]
   schedule:
-  - cron: "0 0 1 * *"
+    - cron: "0 0 1 * *"
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}


### PR DESCRIPTION
x-ref https://discourse.julialang.org/t/documenter-jl-not-updating-link-to-stable-releases/97729

The action needs to run on the tag for Documenter to create a tagged version of the docs.

It looks like Documenter hasn't run for any tag since v0.3.1: https://github.com/tlnagy/Crispulator.jl/tree/gh-pages

I'm not sure why not, but I'm guessing `'v*'` doesn't match `vX.Y.Z` properly? Here's the set I usually use:

https://github.com/jump-dev/JuMP.jl/blob/0c63d61ca868c4048f724e27bebd7532337279eb/.github/workflows/documentation.yml#L2-L7